### PR TITLE
DTSPO-2201 - Add startup probes and upgrade chart-library to 0.6.3 

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -16,10 +16,14 @@ resources:
       name: hmcts/cnp-azuredevops-libraries
       endpoint: 'hmcts'
 
+variables:
+  - name: agentPool
+    value: ubuntu-latest
+
 jobs:
   - job: Validate
     pool:
-      vmImage: 'Ubuntu 18.04'
+      vmImage: ${{ variables.agentPool }}
     strategy:
       matrix:
         java:
@@ -46,7 +50,7 @@ jobs:
         )
     dependsOn: Validate
     pool:
-      vmImage: 'Ubuntu 18.04'
+      vmImage: ${{ variables.agentPool }}
     steps:
       - template: steps/charts/release.yaml@cnp-library
         parameters:

--- a/base/Chart.yaml
+++ b/base/Chart.yaml
@@ -16,7 +16,7 @@ sources:
 icon: https://cncf-branding.netlify.app/img/projects/helm/horizontal/color/helm-horizontal-color.png
 dependencies:
   - name: library
-    version: 0.5.7
+    version: 0.6.3
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: postgresql
     version: 8.9.8

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -20,6 +20,11 @@ livenessDelay: 5
 livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3
+startupPath: /health/liveness
+startupDelay: 5
+startupTimeout: 3
+startupPeriod: 15
+startupFailureThreshold: 3
 saEnabled: true
 devApplicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'
 imagePullPolicy: IfNotPresent
@@ -96,6 +101,7 @@ java:
   devcpuLimits: '2500m'
   readinessDelay: 30
   livenessDelay: 30
+  startupDelay: 5
   devApplicationInsightsInstrumentKeyName: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY
 
 #nodejs Overrides

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -12,18 +12,18 @@ devcpuRequests: 25m
 devmemoryLimits: 512Mi
 devcpuLimits: 500m
 readinessPath: /health/readiness
-readinessDelay: 5
+readinessDelay: 0
 readinessTimeout: 3
 readinessPeriod: 15
 livenessPath: /health/liveness
-livenessDelay: 5
+livenessDelay: 0
 livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3
 startupPath: /health/liveness
 startupDelay: 5
 startupTimeout: 3
-startupPeriod: 15
+startupPeriod: 10
 startupFailureThreshold: 3
 saEnabled: true
 devApplicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'
@@ -99,8 +99,8 @@ java:
   devcpuRequests: '250m'
   devmemoryLimits: '1024Mi'
   devcpuLimits: '2500m'
-  readinessDelay: 30
-  livenessDelay: 30
+  readinessDelay: 0
+  livenessDelay: 0
   startupDelay: 5
   devApplicationInsightsInstrumentKeyName: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2201


### Change description ###
Upgrade chart-library version to 0.6.3
Added startup probe values - introduced in chart-library 0.6.3
Updated pipeline pool agent to use ubuntu-latest


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
