### PR TITLE
Update to OCI, point to ACR for image

### DIFF
--- a/base/Chart.yaml
+++ b/base/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
     repository: oci://hmctspublic.azurecr.io/helm
   - name: postgresql
     version: 13.2.24
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -73,7 +73,9 @@ autoscaling:
 
 postgresql:
   image:
-    tag: '11.16.0'
+      registry: hmctspublic.azurecr.io
+      repository: imported/bitnami/postgresql
+      tag: '11.16.0'
   ## Whether to deploy the Postgres Chart or not
   enabled: false
 ## Default Postgres Configuration parameters

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -73,9 +73,9 @@ autoscaling:
 
 postgresql:
   image:
-      registry: hmctspublic.azurecr.io
-      repository: imported/bitnami/postgresql
-      tag: '11.16.0'
+    registry: hmctspublic.azurecr.io
+    repository: imported/bitnami/postgresql
+    tag: '11.16.0'
   ## Whether to deploy the Postgres Chart or not
   enabled: false
 ## Default Postgres Configuration parameters


### PR DESCRIPTION
11.16.0?

Updating for now so that we're covered in terms of ACR and OCI, will raise a tech improvement to investigate if we still need postgres in here at all.